### PR TITLE
Make null termination configurable and add ability to set signature when sending message

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,6 +28,7 @@ class Configuration implements ConfigurationInterface
             ->scalarNode('password')->isRequired()->cannotBeEmpty()->end()
             ->scalarNode('signature')->isRequired()->cannotBeEmpty()->end()
             ->scalarNode('socket_timeout')->cannotBeEmpty()->defaultValue(10000)->end()
+            ->booleanNode('null_terminate')->cannotBeEmpty()->defaultValue(true)->end()
             ->arrayNode('debug')
                 ->addDefaultsIfNotSet()
                 ->children()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,7 +28,7 @@ class Configuration implements ConfigurationInterface
             ->scalarNode('password')->isRequired()->cannotBeEmpty()->end()
             ->scalarNode('signature')->isRequired()->cannotBeEmpty()->end()
             ->scalarNode('socket_timeout')->cannotBeEmpty()->defaultValue(10000)->end()
-            ->booleanNode('null_terminate')->cannotBeEmpty()->defaultValue(true)->end()
+            ->scalarNode('null_terminate')->defaultTrue()->cannotBeEmpty()->end()
             ->arrayNode('debug')
                 ->addDefaultsIfNotSet()
                 ->children()

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -7,3 +7,4 @@ services:
             - '%kronas_smpp_client.password%'
             - '%kronas_smpp_client.signature%'
             - '%kronas_smpp_client.debug%'
+            - '%kronas_smpp_client.null_terminate%'

--- a/Service/SmppTransmitter.php
+++ b/Service/SmppTransmitter.php
@@ -54,7 +54,13 @@ class SmppTransmitter
         $message = GsmEncoder::utf8_to_gsm0338($message);
         if ($from === null)
         {
-            $from = new SmppAddress($this->signature, SMPP::TON_ALPHANUMERIC);
+            $from = $this->signature;
+        }
+
+        if (is_numeric($from))
+        {
+            $from = new SmppAddress(intval($from), SMPP::TON_INTERNATIONAL, SMPP::NPI_E164);
+
         }
         else
         {

--- a/Service/SmppTransmitter.php
+++ b/Service/SmppTransmitter.php
@@ -46,12 +46,11 @@ class SmppTransmitter
     /**
      * @param string $to
      * @param string $message
-     *
-     * @param null $from
+     * @param null|string $from
      * @param bool $isResponseFullBody
-     * @return string|array|void`
+     * @return string|array|void
      */
-    public function send($to, $message, $from = null, $isResponseFullBody = false)
+    public function send($to, $message, $from = null, $returnFullBody = false)
     {
         $message = GsmEncoder::utf8_to_gsm0338($message);
         if ($from === null)
@@ -69,9 +68,9 @@ class SmppTransmitter
         }
         $to = new SmppAddress(intval($to), SMPP::TON_INTERNATIONAL, SMPP::NPI_E164);
 
-        if($isResponseFullBody)
+        if ($returnFullBody)
         {
-            $this->smpp->setIsResponseFullBody(true);
+            $this->smpp->setReturnFullBody(true);
         }
 
         $this->openSmppConnection();

--- a/Service/SmppTransmitter.php
+++ b/Service/SmppTransmitter.php
@@ -19,6 +19,7 @@ class SmppTransmitter
     private $password;
     private $signature;
     private $debug;
+    private $nullTerminate;
 
     /** @var TransportInterface */
     private $transport;
@@ -32,13 +33,14 @@ class SmppTransmitter
      * @param string $signature
      * @param array  $debug
      */
-    public function __construct(array $transportParamters, $login, $password, $signature, array $debug)
+    public function __construct(array $transportParamters, $login, $password, $signature, array $debug, $nullTerminate)
     {
         $this->transportParamters = $transportParamters;
         $this->login = $login;
         $this->password = $password;
         $this->signature = $signature;
         $this->debug = $debug;
+        $this->nullTerminate = $nullTerminate;
     }
 
     /**
@@ -73,6 +75,8 @@ class SmppTransmitter
         $this->transport->setSendTimeout($this->transportParamters[2]);
 
         $this->smpp = new SmppClient($this->transport);
+
+        $this->smpp->smsNullTerminateOctetStrings = $this->nullTerminate;
 
         $this->transport->debug = $this->debug['transport'];
         $this->smpp->debug = $this->debug['smpp'];

--- a/Service/SmppTransmitter.php
+++ b/Service/SmppTransmitter.php
@@ -47,9 +47,11 @@ class SmppTransmitter
      * @param string $to
      * @param string $message
      *
-     * @return string|void`
+     * @param null $from
+     * @param bool $isResponseFullBody
+     * @return string|array|void`
      */
-    public function send($to, $message, $from = null)
+    public function send($to, $message, $from = null, $isResponseFullBody = false)
     {
         $message = GsmEncoder::utf8_to_gsm0338($message);
         if ($from === null)
@@ -60,7 +62,6 @@ class SmppTransmitter
         if (is_numeric($from))
         {
             $from = new SmppAddress(intval($from), SMPP::TON_INTERNATIONAL, SMPP::NPI_E164);
-
         }
         else
         {
@@ -68,11 +69,16 @@ class SmppTransmitter
         }
         $to = new SmppAddress(intval($to), SMPP::TON_INTERNATIONAL, SMPP::NPI_E164);
 
+        if($isResponseFullBody)
+        {
+            $this->smpp->setIsResponseFullBody(true);
+        }
+
         $this->openSmppConnection();
-        $messageId = $this->smpp->sendSMS($from, $to, $message);
+        $response = $this->smpp->sendSMS($from, $to, $message);
         $this->closeSmppConnection();
 
-        return $messageId;
+        return $response;
     }
 
     private function openSmppConnection()

--- a/Service/SmppTransmitter.php
+++ b/Service/SmppTransmitter.php
@@ -47,10 +47,17 @@ class SmppTransmitter
      *
      * @return string|void`
      */
-    public function send($to, $message)
+    public function send($to, $message, $from = null)
     {
         $message = GsmEncoder::utf8_to_gsm0338($message);
-        $from = new SmppAddress($this->signature, SMPP::TON_ALPHANUMERIC);
+        if ($from === null)
+        {
+            $from = new SmppAddress($this->signature, SMPP::TON_ALPHANUMERIC);
+        }
+        else
+        {
+            $from = new SmppAddress($from, SMPP::TON_ALPHANUMERIC);
+        }
         $to = new SmppAddress(intval($to), SMPP::TON_INTERNATIONAL, SMPP::NPI_E164);
 
         $this->openSmppConnection();

--- a/Service/SmppTransmitter.php
+++ b/Service/SmppTransmitter.php
@@ -69,12 +69,11 @@ class SmppTransmitter
         }
         $to = new SmppAddress(intval($to), SMPP::TON_INTERNATIONAL, SMPP::NPI_E164);
 
+        $this->openSmppConnection();
         if ($returnStatus)
         {
             $this->smpp->setReturnStatus(true);
         }
-
-        $this->openSmppConnection();
         $response = $this->smpp->sendSMS($from, $to, $message);
         $this->closeSmppConnection();
 

--- a/Service/SmppTransmitter.php
+++ b/Service/SmppTransmitter.php
@@ -47,11 +47,11 @@ class SmppTransmitter
      * @param string $to
      * @param string $message
      * @param null|string $from
-     * @param bool $returnFullBody
+     * @param bool $returnStatus
      *
      * @return string|array|void
      */
-    public function send($to, $message, $from = null, $returnFullBody = false)
+    public function send($to, $message, $from = null, $returnStatus = false)
     {
         $message = GsmEncoder::utf8_to_gsm0338($message);
         if ($from === null)
@@ -69,9 +69,9 @@ class SmppTransmitter
         }
         $to = new SmppAddress(intval($to), SMPP::TON_INTERNATIONAL, SMPP::NPI_E164);
 
-        if ($returnFullBody)
+        if ($returnStatus)
         {
-            $this->smpp->setReturnFullBody(true);
+            $this->smpp->setReturnStatus(true);
         }
 
         $this->openSmppConnection();

--- a/Service/SmppTransmitter.php
+++ b/Service/SmppTransmitter.php
@@ -47,7 +47,8 @@ class SmppTransmitter
      * @param string $to
      * @param string $message
      * @param null|string $from
-     * @param bool $isResponseFullBody
+     * @param bool $returnFullBody
+     *
      * @return string|array|void
      */
     public function send($to, $message, $from = null, $returnFullBody = false)

--- a/SmppCore/SmppClient.php
+++ b/SmppCore/SmppClient.php
@@ -54,7 +54,7 @@ class SmppClient
      * Switch to toggle this feature
      * @var boolean
      */
-    public static $smsNullTerminateOctetStrings = true;
+    public $smsNullTerminateOctetStrings = true;
 
     /**
      * Use sarMsgRefNum and sar_total_segments with 16 bit tags
@@ -496,7 +496,7 @@ class SmppClient
         }
 
         // Construct PDU with mandatory fields
-        $pdu = pack('a1cca'.(strlen($source->value)+1).'cca'.(strlen($destination->value)+1).'ccc'.($scheduleDeliveryTime ? 'a16x' : 'a1').($validityPeriod ? 'a16x' : 'a1').'ccccca'.(strlen($shortMessage)+(self::$smsNullTerminateOctetStrings ? 1 : 0)),
+        $pdu = pack('a1cca'.(strlen($source->value)+1).'cca'.(strlen($destination->value)+1).'ccc'.($scheduleDeliveryTime ? 'a16x' : 'a1').($validityPeriod ? 'a16x' : 'a1').'ccccca'.(strlen($shortMessage)+($this->smsNullTerminateOctetStrings ? 1 : 0)),
             self::$smsServiceType,
             $source->ton,
             $source->npi,

--- a/SmppCore/SmppClient.php
+++ b/SmppCore/SmppClient.php
@@ -50,6 +50,12 @@ class SmppClient
     public static $smsSmDefaultMsgId = 0x00;
 
     /**
+     * This is used to return full response body rather than just id
+     * @var bool
+     */
+    protected $isResponseFullBody = false;
+
+    /**
      * SMPP v3.4 says octect string are "not necessarily NULL terminated".
      * Switch to toggle this feature
      * @var boolean
@@ -528,6 +534,11 @@ class SmppClient
         $response = $this->sendCommand(SMPP::SUBMIT_SM, $pdu);
         $body = unpack("a*msgid", $response->body);
 
+        if($this->isResponseFullBody)
+        {
+            return $response->body;
+        }
+
         return $body['msgid'];
     }
 
@@ -991,5 +1002,23 @@ class SmppClient
         }
 
         return $tag;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isResponseFullBody()
+    {
+        return $this->isResponseFullBody;
+    }
+
+    /**
+     * @param bool $isResponseFullBody
+     * @return SmppClient
+     */
+    public function setIsResponseFullBody($isResponseFullBody)
+    {
+        $this->isResponseFullBody = $isResponseFullBody;
+        return $this;
     }
 }

--- a/SmppCore/SmppClient.php
+++ b/SmppCore/SmppClient.php
@@ -49,10 +49,7 @@ class SmppClient
     public static $smsReplaceIfPresentFlag = 0x00;
     public static $smsSmDefaultMsgId = 0x00;
 
-    /**
-     * This is used to return full response body rather than just id
-     * @var bool
-     */
+    /** @var bool $returnFullBody If true return the full body, otherwise just return the ID */
     protected $returnFullBody = false;
 
     /**

--- a/SmppCore/SmppClient.php
+++ b/SmppCore/SmppClient.php
@@ -53,7 +53,7 @@ class SmppClient
      * This is used to return full response body rather than just id
      * @var bool
      */
-    protected $isResponseFullBody = false;
+    protected $returnFullBody = false;
 
     /**
      * SMPP v3.4 says octect string are "not necessarily NULL terminated".
@@ -534,7 +534,7 @@ class SmppClient
         $response = $this->sendCommand(SMPP::SUBMIT_SM, $pdu);
         $body = unpack("a*msgid", $response->body);
 
-        if($this->isResponseFullBody)
+        if ($this->returnFullBody)
         {
             return $response->body;
         }
@@ -1007,18 +1007,18 @@ class SmppClient
     /**
      * @return bool
      */
-    public function isResponseFullBody()
+    public function returnFullBody()
     {
-        return $this->isResponseFullBody;
+        return $this->returnFullBody;
     }
 
     /**
-     * @param bool $isResponseFullBody
+     * @param bool $returnFullBody
      * @return SmppClient
      */
-    public function setIsResponseFullBody($isResponseFullBody)
+    public function setReturnFullBody($returnFullBody)
     {
-        $this->isResponseFullBody = $isResponseFullBody;
+        $this->returnFullBody = $returnFullBody;
         return $this;
     }
 }

--- a/SmppCore/SmppClient.php
+++ b/SmppCore/SmppClient.php
@@ -395,9 +395,11 @@ class SmppClient
         // Figure out if we need to do CSMS, since it will affect our PDU
         if ($msgLength > $singleSmsOctetLimit) {
             $doCsms = true;
+            if (self::$csmsMethod != SmppClient::CSMS_PAYLOAD) {
                 $parts = $this->splitMessageString($message, $csmsSplit, $dataCoding);
                 $shortMessage = reset($parts);
                 $csmsReference = $this->getCsmsReference();
+            }
         } else {
             $shortMessage = $message;
             $doCsms = false;

--- a/SmppCore/SmppClient.php
+++ b/SmppCore/SmppClient.php
@@ -49,8 +49,8 @@ class SmppClient
     public static $smsReplaceIfPresentFlag = 0x00;
     public static $smsSmDefaultMsgId = 0x00;
 
-    /** @var bool $returnFullBody If true return the full body, otherwise just return the ID */
-    protected $returnFullBody = false;
+    /** @var bool $eturnStatus If true return the full body, otherwise just return the ID */
+    protected $eturnStatus = false;
 
     /**
      * SMPP v3.4 says octect string are "not necessarily NULL terminated".
@@ -531,9 +531,9 @@ class SmppClient
         $response = $this->sendCommand(SMPP::SUBMIT_SM, $pdu);
         $body = unpack("a*msgid", $response->body);
 
-        if ($this->returnFullBody)
+        if ($this->getReturnStatus())
         {
-            return $response->body;
+            return $response->status;
         }
 
         return $body['msgid'];
@@ -1004,18 +1004,18 @@ class SmppClient
     /**
      * @return bool
      */
-    public function returnFullBody()
+    public function getReturnStatus()
     {
-        return $this->returnFullBody;
+        return $this->returnStatus;
     }
 
     /**
-     * @param bool $returnFullBody
+     * @param bool $returnStatus
      * @return SmppClient
      */
-    public function setReturnFullBody($returnFullBody)
+    public function setReturnStatus($returnStatus)
     {
-        $this->returnFullBody = $returnFullBody;
+        $this->returnStatus = $returnStatus;
         return $this;
     }
 }

--- a/SmppCore/SmppClient.php
+++ b/SmppCore/SmppClient.php
@@ -395,11 +395,9 @@ class SmppClient
         // Figure out if we need to do CSMS, since it will affect our PDU
         if ($msgLength > $singleSmsOctetLimit) {
             $doCsms = true;
-            if (!self::$csmsMethod != SmppClient::CSMS_PAYLOAD) {
                 $parts = $this->splitMessageString($message, $csmsSplit, $dataCoding);
                 $shortMessage = reset($parts);
                 $csmsReference = $this->getCsmsReference();
-            }
         } else {
             $shortMessage = $message;
             $doCsms = false;

--- a/SmppCore/SmppClient.php
+++ b/SmppCore/SmppClient.php
@@ -49,8 +49,8 @@ class SmppClient
     public static $smsReplaceIfPresentFlag = 0x00;
     public static $smsSmDefaultMsgId = 0x00;
 
-    /** @var bool $eturnStatus If true return the full body, otherwise just return the ID */
-    protected $eturnStatus = false;
+    /** @var bool $returnStatus If true return the status, otherwise just return the ID */
+    protected $returnStatus = false;
 
     /**
      * SMPP v3.4 says octect string are "not necessarily NULL terminated".
@@ -1002,6 +1002,8 @@ class SmppClient
     }
 
     /**
+     * Get the return status, if true a status code will be returned, otherwise a message ID will be returned
+     *
      * @return bool
      */
     public function getReturnStatus()
@@ -1010,7 +1012,10 @@ class SmppClient
     }
 
     /**
+     * Set the return status option, set to true for a status code or false for a message id
+     *
      * @param bool $returnStatus
+     *
      * @return SmppClient
      */
     public function setReturnStatus($returnStatus)


### PR DESCRIPTION
While integrating with our provider I found we needed to disable the null termination of messages.  This PR assists with this by adding a configuration parameter to enable or disable null termination.

Our use-case also requires us to change the signature on a per message basis.  This PR adds an optional parameter to the send function to override the default signature.

Additionally, our provider rejects `TON_ALPHANUMERIC` when the SmppAddress appears to be `TON_INTERNATIONAL`, so detection for that has been added.

Finally, we needed to be able to interpret the status returned from our provider, not just get a message ID; so functionality has been added to enable the return of the status instead of a message ID.