### PR TITLE
Use TON International if signature is numeric

### DIFF
--- a/Service/SmppTransmitter.php
+++ b/Service/SmppTransmitter.php
@@ -50,7 +50,17 @@ class SmppTransmitter
     public function send($to, $message)
     {
         $message = GsmEncoder::utf8_to_gsm0338($message);
-        $from = new SmppAddress($this->signature, SMPP::TON_ALPHANUMERIC);
+        $from = $this->signature;
+
+        if (is_numeric($from))
+        {
+            $from = new SmppAddress(intval($from), SMPP::TON_INTERNATIONAL, SMPP::NPI_E164);
+
+        }
+        else
+        {
+            $from = new SmppAddress($from, SMPP::TON_ALPHANUMERIC);
+        }
         $to = new SmppAddress(intval($to), SMPP::TON_INTERNATIONAL, SMPP::NPI_E164);
 
         $this->openSmppConnection();


### PR DESCRIPTION
Our provider rejects attempts to send messages with a valid international TON if we specify the TON as alpha numeric.,