### PR TITLE
Allow TLV tags to be added to the SmppTransmitter send function

### DIFF
--- a/Service/SmppTransmitter.php
+++ b/Service/SmppTransmitter.php
@@ -5,6 +5,7 @@ namespace Kronas\SmppClientBundle\Service;
 use Kronas\SmppClientBundle\Encoder\GsmEncoder;
 use Kronas\SmppClientBundle\SMPP;
 use Kronas\SmppClientBundle\SmppCore\SmppAddress;
+use Kronas\SmppClientBundle\SmppCore\SmppTag;
 use Kronas\SmppClientBundle\Transport\SocketTransport;
 use Kronas\SmppClientBundle\Transport\TransportInterface;
 use Kronas\SmppClientBundle\SmppCore\SmppClient;
@@ -44,17 +45,18 @@ class SmppTransmitter
     /**
      * @param string $to
      * @param string $message
+     * @param null|SmppTag[] $tags
      *
      * @return string|void`
      */
-    public function send($to, $message)
+    public function send($to, $message, $tags = null)
     {
         $message = GsmEncoder::utf8_to_gsm0338($message);
         $from = new SmppAddress($this->signature, SMPP::TON_ALPHANUMERIC);
         $to = new SmppAddress(intval($to), SMPP::TON_INTERNATIONAL, SMPP::NPI_E164);
 
         $this->openSmppConnection();
-        $messageId = $this->smpp->sendSMS($from, $to, $message);
+        $messageId = $this->smpp->sendSMS($from, $to, $message, $tags);
         $this->closeSmppConnection();
 
         return $messageId;


### PR DESCRIPTION
Add functionality to pass an optional array of SmppTags through the SmppTransmitter send function to allow for TLV parameters to be attached to a message